### PR TITLE
ci: revert registry-url for npmjs to not include scope while setting scope separately

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,8 +95,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: latest
-          registry-url: https://registry.npmjs.org/@kagekirin/
-          scope: ''
+          registry-url: https://registry.npmjs.org/
+          scope: '@kagekirin'
       - name: Patch package.json
         run: sed -i -e "s|npm.pkg.github.com|registry.npmjs.org|g" package.json
       - name: Install dependencies


### PR DESCRIPTION
This reverts commit d067a981e7ad3af0450cf1bd1aedd59ec208cf8a.
