### PR TITLE
ci: use 'yarn' to publish to NPM registries instead of 'npm'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
           rm -r Assets/Editor*
 
       - name: Publish to GitHub NPM Registry
-        run: npm publish --access public
+        run: yarn publish --verbose --non-interactive --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,6 +122,6 @@ jobs:
           rm -r Assets/Editor*
 
       - name: Publish to NPM.JS Registry
-        run: npm publish --access public
+        run: yarn publish --verbose --non-interactive --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
- **ci: use 'yarn' to publish to GitHub NPM registry instead of 'npm'**
- **ci: use 'yarn' to publish to NPMJS registry instead of 'npm'**
